### PR TITLE
Correct byte divisor

### DIFF
--- a/src/main/java/life/qbic/UnitConverter/Bytes.java
+++ b/src/main/java/life/qbic/UnitConverter/Bytes.java
@@ -5,7 +5,7 @@ class Bytes implements UnitDisplay{
 
     private String unit = "bytes";
 
-    private double divisor = Math.pow(10, 1);
+    private double divisor = 1;
 
 
     @Override


### PR DESCRIPTION
The divisor was incorrect, a byte does not be divided by 10.