### PR TITLE
Hotfix 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Hotfix 0.4.2
+
+* Fix wrong display of found files for download
+* Fix wrong exit status. Postman reported to have failed, although all
+  files have been downloaded successfully.
+
 ## Hotfix 0.4.1
 
 * Fix the issue of not finding datasets when filtering by suffix

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.2.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -153,7 +153,7 @@ public class QbicDataDownloader {
     // a suffix was provided -> only download files which contain the suffix string
     if (!commandLineParameters.suffixes.isEmpty()) {
       for (String ident : commandLineParameters.ids) {
-        LOG.info(String.format("Downloading files for provided identifier %s", ident));
+        LOG.info(String.format("Downloading filtered files for provided identifier %s", ident));
         List<DataSetFile> foundSuffixFilteredIDs =
             qbicDataFinder.findAllSuffixFilteredIDs(ident, commandLineParameters.suffixes);
 
@@ -222,7 +222,7 @@ public class QbicDataDownloader {
       try {
         List<DataSetFile> filteredDataSetFiles = removeDirectories(foundFilteredDatasets);
         final DownloadRequest downloadRequest = new DownloadRequest(filteredDataSetFiles);
-        downloadFiles(downloadRequest);
+        filesDownloadReturnCode = downloadFiles(downloadRequest);
       } catch (NullPointerException e) {
         LOG.error(
             "Datasets were found by the application server, but could not be found on the datastore server for "
@@ -349,7 +349,7 @@ public class QbicDataDownloader {
     return finalPath;
   }
 
-  private void downloadFiles(DownloadRequest request) throws DownloadException {
+  private int downloadFiles(DownloadRequest request) throws DownloadException {
     request
         .getDataSets()
         .forEach(
@@ -364,6 +364,7 @@ public class QbicDataDownloader {
               }
               writeCRC32Checksum(dataSetFile);
             });
+    return 0;
   }
 
   private void writeCRC32Checksum(DataSetFile dataSetFile) {

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -142,7 +142,8 @@ public class QbicDataFinder {
       // remove everything that doesn't match the suffix -> only add if suffix matches
       for (DataSetFile file : files) {
         for (String suffix : suffixes) {
-          if (StringUtil.endsWithIgnoreCase(file.getPath(), suffix)) {
+          // We omit directories and check files for suffix pattern
+          if ((!file.isDirectory()) && StringUtil.endsWithIgnoreCase(file.getPath(), suffix)) {
             filesFiltered.add(file);
           }
         }


### PR DESCRIPTION
This Hotfix fixes two issues:

1) A wrong display of the number of downloaded files
2) A wrong exit status report. Although downloads are successfull when using suffixes
postman reported to have failed.