### PR TITLE
hotifx/0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Hotfix 0.4.3
+
+* Fix #65 and #47
+
 ## Hotfix 0.4.2
 
 * Fix wrong display of found files for download

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.2.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/src/main/groovy/life/qbic/DownloadRequest.groovy
+++ b/src/main/groovy/life/qbic/DownloadRequest.groovy
@@ -16,8 +16,11 @@ class DownloadRequest {
 
     final private Map<String, DataSetFile> dataSetByPermId
 
+    private String sampleCode
+
     DownloadRequest() {
         this.dataSetByPermId = new HashMap<>()
+        this.sampleCode = ""
     }
 
     /**
@@ -25,8 +28,9 @@ class DownloadRequest {
      *
      * @param dataSetFiles
      */
-    DownloadRequest(List<DataSetFile> dataSetFiles) {
+    DownloadRequest(List<DataSetFile> dataSetFiles, String sampleCode) {
         this()
+        this.sampleCode = sampleCode
         dataSetFiles.each { dsFile ->
             addDataSet(dsFile.getPermId().toString(), dsFile)
         }
@@ -65,6 +69,10 @@ class DownloadRequest {
      */
     List<DataSetFile> getDataSets() {
         dataSetByPermId.values().collect()
+    }
+
+    String getSampleCode() {
+        sampleCode
     }
 
 }

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
@@ -176,14 +177,18 @@ public class QbicDataDownloader {
       // no suffix or regex was supplied -> download all datasets
       for (String ident : commandLineParameters.ids) {
         LOG.info(String.format("Downloading files for provided identifier %s", ident));
-        Set<DataSet> foundDataSets = new HashSet<>(qbicDataFinder.findAllDatasetsRecursive(ident));
+        List<Map<String, List<DataSet>>> foundDataSets =
+            qbicDataFinder.findAllDatasetsRecursive(ident);
 
+        //Todo: implement method that determines the number of found datasets
         LOG.info(String.format("Number of datasets found: %s", foundDataSets.size()));
 
         if (foundDataSets.size() > 0) {
           LOG.info("Initialize download ...");
           int datasetDownloadReturnCode = -1;
           try {
+            // Todo: Adjust downloadDataset method such that it creates folders
+            // for the sample code and aggregates datasets per sample code
             datasetDownloadReturnCode =
                 qbicDataDownloader.downloadDataset(new LinkedList<>(foundDataSets));
           } catch (NullPointerException e) {

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -181,7 +181,7 @@ public class QbicDataDownloader {
             qbicDataFinder.findAllDatasetsRecursive(ident);
 
         //Todo: implement method that determines the number of found datasets
-        LOG.info(String.format("Number of datasets found: %s", foundDataSets.size()));
+        LOG.info(String.format("Number of datasets found: %s", countDatasets(foundDataSets)));
 
         if (foundDataSets.size() > 0) {
           LOG.info("Initialize download ...");
@@ -189,8 +189,8 @@ public class QbicDataDownloader {
           try {
             // Todo: Adjust downloadDataset method such that it creates folders
             // for the sample code and aggregates datasets per sample code
-            datasetDownloadReturnCode =
-                qbicDataDownloader.downloadDataset(new LinkedList<>(foundDataSets));
+            //datasetDownloadReturnCode =
+            //    qbicDataDownloader.downloadDataset(foundDataSets);
           } catch (NullPointerException e) {
             LOG.error(
                 "Datasets were found by the application server, but could not be found on the datastore server for "
@@ -210,6 +210,17 @@ public class QbicDataDownloader {
         }
       }
     }
+  }
+
+  private Integer countDatasets(List<Map<String, List<DataSet>>> datasetsPerSampleCode) {
+    int sum = 0;
+    for (Map<String, List<DataSet>> entry : datasetsPerSampleCode){
+      for (String sampleCode : entry.keySet()) {
+        System.out.println(sampleCode);
+        sum += entry.get(sampleCode).size();
+      }
+    }
+    return sum;
   }
 
   /**

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -57,11 +57,16 @@ public class QbicDataFinder {
     // fetch all datasets of the children
     for (Sample child : sample.getChildren()) {
       List<DataSet> foundChildrenDatasets = child.getDataSets();
-      foundSets.put(sample.getCode(), foundChildrenDatasets);
-      result.add(foundSets);
-      result.addAll(fetchDesecendantDatasets(child));
+      if (!foundChildrenDatasets.isEmpty()) {
+        foundSets.put(child.getCode(), foundChildrenDatasets);
+      }
+      if (!fetchDesecendantDatasets(child).isEmpty()) {
+        result.addAll(fetchDesecendantDatasets(child));
+      }
     }
-
+    if (!foundSets.isEmpty()){
+      result.add(foundSets);
+    }
     return result;
   }
 
@@ -88,15 +93,14 @@ public class QbicDataFinder {
     List<Map<String, List<DataSet>>> dataSetsBySampleId = new ArrayList<>();
 
     for (Sample sample : result.getObjects()) {
-      System.out.println(sample.getCode());
       // add the datasets of the sample itself
-      foundSets.put(sample.getCode(), sample.getDataSets());
-      dataSetsBySampleId.add(foundSets);
-
+      if (!sample.getDataSets().isEmpty()) {
+        foundSets.put(sample.getCode(), sample.getDataSets());
+        dataSetsBySampleId.add(foundSets);
+      }
       // fetch all datasets of the children
       dataSetsBySampleId.addAll(fetchDesecendantDatasets(sample));
     }
-
     return dataSetsBySampleId;
 
     // Currently omitting the type filter with 0.4.3
@@ -123,10 +127,12 @@ public class QbicDataFinder {
    * @return
    */
   public List<DataSetFile> findAllRegexFilteredIDs(String ident, List<String> regexPatterns) {
-    List<DataSet> allDatasets = findAllDatasetsRecursive(ident);
+    // TODO adjust for datasets per sample
+    //List<DataSet> allDatasets = findAllDatasetsRecursive(ident);
 
+    // TODO replace empty list
     return QbicDataLoaderRegexUtil.findAllRegexFilteredIDsGroovy(
-        regexPatterns, allDatasets, dataStoreServer, sessionToken);
+        regexPatterns, new ArrayList<>(), dataStoreServer, sessionToken);
   }
 
   /**
@@ -137,8 +143,9 @@ public class QbicDataFinder {
    * @return
    */
   public List<DataSetFile> findAllSuffixFilteredIDs(String ident, List<String> suffixes) {
-    List<DataSet> allDatasets = findAllDatasetsRecursive(ident);
-
+    // TODO adjust type
+    //List<DataSet> allDatasets = findAllDatasetsRecursive(ident);
+    List<DataSet> allDatasets = new ArrayList<>();
     List<DataSetFile> allFileIDs = new ArrayList<>();
 
     for (DataSet ds : allDatasets) {


### PR DESCRIPTION
This PR fixes a problem when files are overwritten because
there are several measurements available per sample.
The fix results in directories that are created and containing 
the name of the sample a dataset is attached to.
This is also supposed to work for recursive downloads,
where the given sample has child samples with attached datasets.

When downloading Nanopore datasets, make sure to use 
the --conserve option, to distiguish beetween pass and fail
folders of the same sample.