### PR TITLE
Enable two additional download attempts on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Hotfix 0.4.4
+
+* Download attempts are now configured, to try two additional times to
+  download a dataset, if the attempt fails. This addresses random
+  time-out exception events that have been reported by a user.
+
 ## Hotfix 0.4.3
 
 * Fix #65 and #47

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.2.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/src/main/groovy/life/qbic/DownloadRequest.groovy
+++ b/src/main/groovy/life/qbic/DownloadRequest.groovy
@@ -54,7 +54,7 @@ class DownloadRequest {
         dataSetFiles.each { dsFile ->
             addDataSet(dsFile.getPermId().toString(), dsFile)
         }
-        this.retries = numberRetries
+        this.retries = numberRetries >= 1 ? numberRetries : 1
     }
 
     /**

--- a/src/main/groovy/life/qbic/DownloadRequest.groovy
+++ b/src/main/groovy/life/qbic/DownloadRequest.groovy
@@ -18,9 +18,12 @@ class DownloadRequest {
 
     private String sampleCode
 
+    private int retries
+
     DownloadRequest() {
         this.dataSetByPermId = new HashMap<>()
         this.sampleCode = ""
+        this.retries = 1
     }
 
     /**
@@ -34,6 +37,24 @@ class DownloadRequest {
         dataSetFiles.each { dsFile ->
             addDataSet(dsFile.getPermId().toString(), dsFile)
         }
+        this.retries = 1
+    }
+
+    /**
+     * Download request constructor with a provided list of data set files and a configured
+     * number of retries on failure.
+     *
+     * @param dataSetFiles
+     * @param sampleCode
+     * @param numberRetries The number of retries. Must be >=1, else it will be set to 1
+     */
+    DownloadRequest(List<DataSetFile> dataSetFiles, String sampleCode, int numberRetries) {
+        this()
+        this.sampleCode = sampleCode
+        dataSetFiles.each { dsFile ->
+            addDataSet(dsFile.getPermId().toString(), dsFile)
+        }
+        this.retries = numberRetries
     }
 
     /**
@@ -61,6 +82,14 @@ class DownloadRequest {
             new IllegalArgumentException("The provided argument does not represent a known ID.")
         }
         return dataSetByPermId[permId].checksumCRC32
+    }
+
+    /**
+     * Returns the max number of attempts for the download request.
+     * @return The number of attempts to perform, if the download fails
+     */
+    int getMaxNumberOfAttempts() {
+        return retries
     }
 
     /**


### PR DESCRIPTION
Download attempts are now configured, to try two additional times to
  download a dataset, if the attempt fails. This addresses random
  time-out exception events that have been reported by a user.