### PR TITLE
Use port 443 for dss default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Hotfix 0.4.5 (2021-03-25)
+
+* Default dss route is now using port 443 and not 444 anymore. Port 444
+  is a system reserved port that is blocked on many systems. With a
+  proper proxy setup now, there is no need to go over port 444 anymore.
+
 ## Hotfix 0.4.4
 
 * Download attempts are now configured, to try two additional times to

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.2.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.4.4</version>
+    <version>0.4.5</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
+++ b/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
@@ -60,7 +60,7 @@ public class PostmanCommandLineOptions {
   @Option(
       names = {"-dss", "--dss_url"},
       description = "DataStoreServer URL")
-  public String dss_url = "https://qbis.qbic.uni-tuebingen.de:444/datastore_server";
+  public String dss_url = "https://qbis.qbic.uni-tuebingen.de/datastore_server";
 
   @Option(
       names = {"-as", "-as_url"},


### PR DESCRIPTION
Since on many systems, administrators block the system reserved port 444 by default, we changed our proxy setup and route the data store stream via 443 back to the client. 
Therefore, the default datastore URL and port is adjusted in this PR to use port 443 by default.