### PR TITLE
Fix duplicate DS download

### DIFF
--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -102,8 +102,6 @@ public class QbicDataFinder {
       }
       Map<String, List<DataSet>> sampleDatasetMap = fetchDescendantDatasets(sample,searchedSamples);
       dataSetsBySampleId = joinMaps(dataSetsBySampleId, sampleDatasetMap);
-      LOG.info("visited: "+searchedSamples.toString());
-      LOG.info("Found samples: "+sampleDatasetMap.keySet());
       //remember what has been searched
       searchedSamples.addAll(sampleDatasetMap.keySet());
     }

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -106,8 +106,9 @@ public class QbicDataFinder {
   }
 
   private static <T> List<T> joinLists(List<T> list1, List<T> list2) {
-    List<T> joinedList = new ArrayList<>();
-    Stream.of(list1, list2).forEach(joinedList::addAll);
+    List<T> joinedList = new ArrayList<>(list1);
+    joinedList.removeAll(list2);
+    joinedList.addAll(list2);
     return joinedList;
   }
 

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -79,6 +79,9 @@ public class QbicDataFinder {
    * @return all found datasets for a given sampleID
    */
   public Map<String, List<DataSet>> findAllDatasetsRecursive(String sampleId) {
+    List<String> searchedSamples = new ArrayList<>();
+    Map<String, List<DataSet>> dataSetsBySampleId = new HashMap<>();
+
     SampleSearchCriteria criteria = new SampleSearchCriteria();
     criteria.withCode().thatEquals(sampleId);
 
@@ -88,12 +91,11 @@ public class QbicDataFinder {
     dsFetchOptions.withType();
     fetchOptions.withChildrenUsing(fetchOptions);
     fetchOptions.withDataSetsUsing(dsFetchOptions);
+
     SearchResult<Sample> result =
         applicationServer.searchSamples(sessionToken, criteria, fetchOptions);
-    Map<String, List<DataSet>> dataSetsBySampleId = new HashMap<>();
-
     List<Sample> samples = result.getObjects();
-    List<String> searchedSamples = new ArrayList<>();
+
     for (Sample sample : samples) {
       if(searchedSamples.contains(sample.getCode())){
         continue;
@@ -118,7 +120,6 @@ public class QbicDataFinder {
   }
 
   private static <T> List<T> joinLists(List<T> list1, List<T> list2) {
-    //todo introduce old code here again
     List<T> joinedList = new ArrayList<>();
     Stream.of(list1, list2).forEach(joinedList::addAll);
     return joinedList;


### PR DESCRIPTION
Each dataset is downloaded 3 times because the DS search looks into every sample level we have (Biological Entities, Biological Samples and Preparation Samples). This would be no problem, if the elements that are joined after the search were checked for duplicates. 
Therefore, the fix for this bug is to remove duplicates from the joined lists. These lists contain the found DS for samples. Afterall, there should be no case were duplicated entries would be required. (If I am wrong here, please let me know!)  