### PR TITLE
Fix severity issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release 0.5.1 (2021-12-13)
+
+* Fix severity issue CVE-2021-44228 (org.apache.logging.log4j 2.11.0 -> 2.15.0)
+
 ## Release 0.5.0 (2021-12-07)
 
 * Introduce feature to parse the password from environment variable

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.2.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>
@@ -20,6 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.5.1</groovy.version>
+        <log4j.version>2.15.0</log4j.version>
     </properties>
 
     <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
@@ -53,6 +54,13 @@
     </repositories>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>core-utils-lib</artifactId>


### PR DESCRIPTION
## Release 0.5.1 (2021-12-13)

* Fix severity issue CVE-2021-44228 (org.apache.logging.log4j 2.11.0 -> 2.15.0)