### PR TITLE
Hotfix 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Bump `life.qbic:cli-parent-pom:2.2.0` -> `2.3.0`
 * Bump `life.qbic:core-utils-lib:1.0.0` -> `1.6.0`
-* Bump `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0`
-* Bump `org.apache.logging.log4j:log4j-core: 2.15.0` -> `2.16.0`
+* Bump `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0` (CVE-2021-45046)
+* Bump `org.apache.logging.log4j:log4j-core: 2.15.0` -> `2.16.0` (CVE-2021-45046)
 * Bump `org.codehaus.groovy:groovy:2.5.1` -> `2.5.13`
 
 ## Hotfix 0.5.1 (2021-12-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Release 0.5.1 (2021-12-13)
+## Hotfix 0.5.2 (2021-12-15)
+
+* Bump `life.qbic:cli-parent-pom:2.2.0` -> `2.3.0`
+* Bump `life.qbic:core-utils-lib:1.0.0` -> `1.6.0`
+* Bump `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0`
+* Bump `org.apache.logging.log4j:log4j-core: 2.15.0` -> `2.16.0`
+* Bump `org.codehaus.groovy:groovy:2.5.1` -> `3.0.8`
+
+## Hotfix 0.5.1 (2021-12-13)
 
 * Fix severity issue CVE-2021-44228 (org.apache.logging.log4j 2.11.0 -> 2.15.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Bump `life.qbic:core-utils-lib:1.0.0` -> `1.6.0`
 * Bump `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0`
 * Bump `org.apache.logging.log4j:log4j-core: 2.15.0` -> `2.16.0`
-* Bump `org.codehaus.groovy:groovy:2.5.1` -> `3.0.8`
+* Bump `org.codehaus.groovy:groovy:2.5.1` -> `2.5.13`
 
 ## Hotfix 0.5.1 (2021-12-13)
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.3.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>3.0.8</groovy.version>
+        <groovy.version>2.5.13</groovy.version>
         <log4j.version>2.16.0</log4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,23 +99,8 @@
             <classifier>indy</classifier>
         </dependency>
 
-        <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-            <version>2.14.6</version>
-        </dependency>
 
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
 
-        <dependency>
-            <groupId>life.qbic.openbis</groupId>
-            <artifactId>openbis-api-with-deps</artifactId>
-            <version>18.06.5</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jline</groupId>
-            <artifactId>jline</artifactId>
-            <version>2.14.6</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
         </dependency>
 
         <dependency>
-            <groupId>life.qbic</groupId>
-            <artifactId>core-utils-lib</artifactId>
-            <version>1.6.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
             </snapshots>
             <id>nexus-snapshots</id>
             <name>QBiC Snapshots</name>
-            <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
+            <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
         </repository>
         <repository>
             <releases>
@@ -49,7 +49,38 @@
             </snapshots>
             <id>nexus-releases</id>
             <name>QBiC Releases</name>
+            <url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+            <id>nexus-snapshots-old</id>
+            <name>QBiC Snapshots Old</name>
+            <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>nexus-releases-old</id>
+            <name>QBiC Releases Old</name>
             <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
+        </repository>
+        <repository>
+            <id>vaadin-addons</id>
+            <name>Vaadin Addons</name>
+            <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>cli-parent-pom</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
     <version>0.5.1</version>
@@ -19,8 +19,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>2.5.1</groovy.version>
-        <log4j.version>2.15.0</log4j.version>
+        <groovy.version>3.0.8</groovy.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>core-utils-lib</artifactId>
-            <version>1.0.0</version>
+            <version>1.6.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

* Bump `life.qbic:cli-parent-pom:2.2.0` -> `2.3.0`
* Bump `life.qbic:core-utils-lib:1.0.0` -> `1.6.0`
* Bump `org.apache.logging.log4j:log4j-api:2.15.0` -> `2.16.0` (CVE-2021-45046)
* Bump `org.apache.logging.log4j:log4j-core: 2.15.0` -> `2.16.0` (CVE-2021-45046)
* Bump `org.codehaus.groovy:groovy:2.5.1` -> `2.5.13`
