### PR TITLE
Hotfix 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Hotfix 0.5.3 (2021-12-20)
 
 * Bump `org.apache.logging.log4j:log4j-core:2.16.0` -> `2.17.0` (CVE-2021-45105)
+* Bump `org.codehaus.groovy:groovy:2.5.13` -> `2.5.15`
 
 ## Hotfix 0.5.2 (2021-12-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Hotfix 0.5.3 (2021-12-20)
+
+* Bump `org.apache.logging.log4j:log4j-core:2.16.0` -> `2.17.0` (CVE-2021-45105)
 
 ## Hotfix 0.5.2 (2021-12-15)
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>2.5.13</groovy.version>
+        <groovy.version>2.5.15</groovy.version>
         <log4j.version>2.17.0</log4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>2.3.0</version>
     </parent>
     <artifactId>postman-cli</artifactId>
-    <version>0.5.2</version>
+    <version>0.5.3</version>
     <name>Postman cli</name>
     <url>http://github.com/qbicsoftware/postman-cli</url>
     <description>A client software written in Java for dataset downloads from QBiC's data management system openBIS </description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.5.13</groovy.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
     </properties>
 
     <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->


### PR DESCRIPTION
## Hotfix 0.5.3 (2021-12-20)

* Bump `org.apache.logging.log4j:log4j-core:2.16.0` -> `2.17.0` (CVE-2021-45105)
* Bump `org.codehaus.groovy:groovy:2.5.13` -> `2.5.15`