### PR TITLE
Added subcommands for download and status

### DIFF
--- a/src/main/java/life/qbic/io/commandline/CommandLineParser.java
+++ b/src/main/java/life/qbic/io/commandline/CommandLineParser.java
@@ -11,7 +11,7 @@ public class CommandLineParser {
    * verifies whether all mandatory commandline parameters have been passed (IDs and username)
    *
    * @param args
-   * @return
+   * @return commandline parameters
    * @throws IOException
    */
   public static PostmanCommandLineOptions parseAndVerifyCommandLineParameters(String[] args)
@@ -20,15 +20,21 @@ public class CommandLineParser {
       CommandLine.usage(new PostmanCommandLineOptions(), System.out);
       System.exit(0);
     }
-
     PostmanCommandLineOptions commandLineParameters = new PostmanCommandLineOptions();
-    new CommandLine(commandLineParameters).parse(args);
+    CommandLine.ParseResult parsed = new CommandLine(commandLineParameters).parseArgs(args);
 
+
+
+    //System.out.println(parsed.subcommand().commandSpec().name().matches("status"));
     if (commandLineParameters.helpRequested) {
       CommandLine.usage(new PostmanCommandLineOptions(), System.out);
       System.exit(0);
     }
-
+    if(parsed.subcommands().isEmpty()){
+      System.out.println(
+              "You have to provide one of the following subcommands: status, download");
+      System.exit(1);
+    }
     if ((commandLineParameters.ids == null || commandLineParameters.ids.isEmpty())
         && commandLineParameters.filePath == null) {
       System.out.println(
@@ -44,5 +50,11 @@ public class CommandLineParser {
     }
 
     return commandLineParameters;
+  }
+
+  public static String getSubcommand(String[] args){
+    PostmanCommandLineOptions commandLineParameters = new PostmanCommandLineOptions();
+    CommandLine.ParseResult parsed = new CommandLine(commandLineParameters).parseArgs(args);
+    return parsed.subcommand().commandSpec().name();
   }
 }

--- a/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
+++ b/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
@@ -3,6 +3,7 @@ package life.qbic.io.commandline;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -13,73 +14,90 @@ import picocli.CommandLine.Parameters;
         "Optional: specify a config file by running postman with '@/path/to/config.txt'. Details can be found in the README.",
     description =
         "A client software for dataset downloads from QBiC's data management system openBIS.")
+
 public class PostmanCommandLineOptions {
+
+  @Command(name = "download", description = "Download data from OpenBis")
+    public String download() {
+      return "download";
+    }
+
+  @Command(name = "status", description = "provides the status of the datasets of the given identifiers")
+    public String status() {
+      return "status";
+    }
 
   @Option(
       names = {"-u", "--user"},
       required = true,
-      description = "openBIS user name")
+      description = "openBIS user name",
+          scope = CommandLine.ScopeType.INHERIT)
   public String user;
 
   @Option(
       names = {"-p", "--env-password"},
-      description = "provide the name of an environment variable to read in the password from")
+      description = "provide the name of an environment variable to read in the password from",
+      scope = CommandLine.ScopeType.INHERIT)
   public String passwordEnvVariable;
 
   // this consumes all parameters that are not labeled!
-  @Parameters(paramLabel = "SAMPLE_ID", description = "one or more QBiC sample ids")
+  @Parameters(paramLabel = "SAMPLE_ID", description = "one or more QBiC sample ids", scope = CommandLine.ScopeType.INHERIT)
   public List<String> ids;
 
   @Option(
       names = {"-f", "--file"},
-      description = "a file with line-separated list of QBiC sample ids")
+      description = "a file with line-separated list of QBiC sample ids",
+      scope = CommandLine.ScopeType.INHERIT)
   public Path filePath;
 
   @Option(
       names = {"-c", "--conserve"},
-      description = "Conserve the file path structure during download")
+      description = "Conserve the file path structure during download",
+      scope = CommandLine.ScopeType.INHERIT)
   public boolean conservePath;
-
-  @Option(
-      names = {"--print"},
-      description = "print available datasets for the provided samples")
-  public boolean printDatasets;
 
   @Option(
       names = {"-b", "--buffer-size"},
       description =
           "dataset download performance can be improved by increasing this value with a multiple of 1024 (default)."
-              + " Only change this if you know what you are doing.")
+              + " Only change this if you know what you are doing.",
+      scope = CommandLine.ScopeType.INHERIT)
   public int bufferMultiplier = 1;
 
   @Option(
       names = {"-s", "--suffix"},
-      description = "returns all files of datasets containing the supplied suffix")
+      description = "returns all files of datasets containing the supplied suffix",
+      scope = CommandLine.ScopeType.INHERIT)
   public List<String> suffixes = new ArrayList<>();
 
   @Option(
       names = {"-r", "--regex"},
-      description = "returns all files of datasets using your supplied regular expression")
+      description = "returns all files of datasets using your supplied regular expression",
+      scope = CommandLine.ScopeType.INHERIT)
   public List<String> regexPatterns = new ArrayList<>();
 
   @Option(
       names = {"-t", "--type"},
-      description = "filter for a given openBIS dataset type")
+      description = "filter for a given openBIS dataset type",
+      scope = CommandLine.ScopeType.INHERIT)
   public String datasetType = "";
 
   @Option(
       names = {"-dss", "--dss_url"},
-      description = "DataStoreServer URL")
+      description = "DataStoreServer URL",
+      scope = CommandLine.ScopeType.INHERIT)
   public String dss_url = "https://qbis.qbic.uni-tuebingen.de/datastore_server";
 
   @Option(
       names = {"-as", "-as_url"},
-      description = "ApplicationServer URL")
+      description = "ApplicationServer URL",
+      scope = CommandLine.ScopeType.INHERIT)
   public String as_url = "https://qbis.qbic.uni-tuebingen.de/openbis/openbis";
 
   @Option(
       names = {"-h", "--help"},
       usageHelp = true,
-      description = "display a help message")
+      description = "display a help message",
+      scope = CommandLine.ScopeType.INHERIT)
   public boolean helpRequested = false;
 }

--- a/src/main/java/life/qbic/model/download/Authentication.java
+++ b/src/main/java/life/qbic/model/download/Authentication.java
@@ -1,0 +1,62 @@
+package life.qbic.model.download;
+
+import ch.ethz.sis.openbis.generic.asapi.v3.IApplicationServerApi;
+import ch.systemsx.cisd.common.spring.HttpInvokerUtils;
+
+public class Authentication {
+
+    private static String sessionToken;
+    private String user;
+    private String password;
+    private final IApplicationServerApi applicationServer;
+
+
+    public Authentication(
+            String user,
+            String password,
+            String AppServerUri) {
+        this.user = user;
+        this.password = password;
+        if (!AppServerUri.isEmpty()) {
+            this.applicationServer =
+                    HttpInvokerUtils.createServiceStub(
+                            IApplicationServerApi.class, AppServerUri + IApplicationServerApi.SERVICE_URL, 10000);
+        } else {
+            this.applicationServer = null;
+        }
+        this.setCredentials(user, password);
+    }
+
+    /**
+     * Login method for openBIS authentication
+     *
+     * returns 0 if successful, 1 else
+     */
+    public void login() throws ConnectionException, AuthenticationException {
+        try {
+            sessionToken = applicationServer.login(user, password);
+        } catch (Exception e) {
+            throw new ConnectionException("Connection to openBIS server failed.");
+        }
+        if (sessionToken == null || sessionToken.isEmpty()) {
+            throw new AuthenticationException("Authentication failed. Are you using the correct "
+                    + "credentials for http://qbic.life?");
+        }
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+
+    /**
+     * Setter for user and password credentials
+     *
+     * @param user     The openBIS user
+     * @param password The openBIS user's password
+     */
+    public void setCredentials(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+}

--- a/src/main/java/life/qbic/model/download/QbicDataStatus.java
+++ b/src/main/java/life/qbic/model/download/QbicDataStatus.java
@@ -1,0 +1,93 @@
+package life.qbic.model.download;
+
+import ch.ethz.sis.openbis.generic.asapi.v3.IApplicationServerApi;
+import ch.ethz.sis.openbis.generic.asapi.v3.dto.common.search.SearchResult;
+import ch.ethz.sis.openbis.generic.asapi.v3.dto.dataset.DataSet;
+import ch.ethz.sis.openbis.generic.asapi.v3.dto.dataset.id.DataSetPermId;
+import ch.ethz.sis.openbis.generic.dssapi.v3.IDataStoreServerApi;
+import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile;
+import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.fetchoptions.DataSetFileFetchOptions;
+import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.search.DataSetFileSearchCriteria;
+import ch.systemsx.cisd.common.spring.HttpInvokerUtils;
+import life.qbic.io.commandline.PostmanCommandLineOptions;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public class QbicDataStatus {
+    private final IApplicationServerApi applicationServer;
+    private final IDataStoreServerApi dataStoreServer;
+    String filterType;
+    String sessionToken;
+
+    public QbicDataStatus(
+            String AppServerUri,
+            String DataServerUri,
+            String filterType,
+            String sessionToken) {
+        this.filterType = filterType;
+        this.sessionToken = sessionToken;
+        if (!AppServerUri.isEmpty()) {
+            this.applicationServer =
+                    HttpInvokerUtils.createServiceStub(
+                            IApplicationServerApi.class, AppServerUri + IApplicationServerApi.SERVICE_URL, 10000);
+        } else {
+            this.applicationServer = null;
+        }
+        if (!DataServerUri.isEmpty()) {
+            this.dataStoreServer =
+                    HttpInvokerUtils.createStreamSupportingServiceStub(
+                            IDataStoreServerApi.class, DataServerUri + IDataStoreServerApi.SERVICE_URL, 10000);
+        } else {
+            this.dataStoreServer = null;
+        }
+    }
+
+    public void GetDataStatus(PostmanCommandLineOptions commandLineParameters){
+        QbicDataFinder qbicDataFinder =
+                new QbicDataFinder(applicationServer, dataStoreServer, sessionToken, filterType);
+
+        for (String ident : commandLineParameters.ids) {
+            Map<String, List<DataSet>> foundDataSets = qbicDataFinder.findAllDatasetsRecursive(ident);
+            System.out.printf("Number of datasets found for identifier %s : %s%n", ident,
+                    QbicDataDownloader.countDatasets(foundDataSets));
+            if (foundDataSets.size() > 0) {
+                printFileInformation(foundDataSets);
+            }
+        }
+    }
+
+    private void printFileInformation(Map<String, List<DataSet>> sampleDataSets) {
+
+            for (Map.Entry<String, List<DataSet>> entry : sampleDataSets.entrySet()) {
+                for (DataSet dataSet : entry.getValue()) {
+                    DataSetPermId permID = dataSet.getPermId();
+                    System.out.printf("\tDataset %s (%s)%n",permID,entry.getKey());
+                    List<DataSetFile> dataSetFiles = getFiles(permID);
+                    for (DataSetFile file : dataSetFiles) {
+                        String filePath = file.getPermId().getFilePath();
+                        String name = filePath.substring(filePath.lastIndexOf("/") + 1);
+                        Long length = file.getFileLength();
+                        String unit = "Bytes";
+                        Date registrationDate = file.getDataStore().getRegistrationDate();
+                        String iso_registrationDate = registrationDate.toInstant().atZone(ZoneId.systemDefault())
+                                .toLocalDateTime()
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss"));
+
+                        System.out.printf("\t\t%s\t%s\t%s %s%n",iso_registrationDate, name, length, unit);
+                    }
+                }
+            }
+    }
+
+    private List<DataSetFile> getFiles(DataSetPermId permID) {
+        DataSetFileSearchCriteria criteria = new DataSetFileSearchCriteria();
+        criteria.withDataSet().withCode().thatEquals(permID.getPermId());
+        SearchResult<DataSetFile> result =
+                this.dataStoreServer.searchFiles(sessionToken, criteria,
+                        new DataSetFileFetchOptions());
+        return QbicDataDownloader.withoutDirectories(result.getObjects());
+    }
+}


### PR DESCRIPTION
Changes: 
- 2 new classes, Qbicdatastatus and Authentication
- subcommand status: Information about available Datasets and their files will be portrayed in the console
- subcommand download: requested samples will be downloaded like before
- moved the login to openbis into the authentication class because status and download both need it
- removed some warnings

Open questions:
- should login stay in its own class?
- There is probably a better way to use subcommands with picocli
- Missing: options for only one of the subcommands

Thank you for reviewing!
