### PR TITLE
Fix command line output for the download command and allow for multiple DSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ To use our openBIS URL we write the following lines in the config file:
 
 # The following config file options are currently supported:    
 # AS_URL (Application Server URL)       
--as [URL]
+-as <URL>
 # DSS_URL (DataStore Server URL)     
--dss [URL]
+-dss <URL>[,<URL>...]
 
 ```
 A default file is provided here: [default-config](https://github.com/qbicsoftware/postman-cli/blob/development/config.txt). If no config file is provided, postman uses the default values set in the PostmanCommandLineOptions class.
 
 If no config file or commandline option is provided, Postman will resort to the defaults set here: [Defaults](https://github.com/qbicsoftware/postman-cli/blob/development/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java).    
 Hence, the default AS is set to: `https://qbis.qbic.uni-tuebingen.de/openbis/openbis`  
-and the DSS defaults to: `https://qbis.qbic.uni-tuebingen.de/datastore_server`
+and the DSS defaults to: `https://qbis.qbic.uni-tuebingen.de/datastore_server` and `https://qbis.qbic.uni-tuebingen.de/datastore_server2`
 
 ## How to use
 
@@ -82,7 +82,8 @@ Options:
   -p, --env-password=<passwordEnvVariable>  provide the name of an environment variable to read
                                               in the password from
   -as, -as_url=<as_url>                     ApplicationServer URL
-  -dss, --dss_url=<dss_url>                 DataStoreServer URL
+  -dss, --dss_url=<url>[,<url>...]          DataStoreServer URLs. Specifies the 
+                                              data store servers where data can be found.
   -f, --file=<filePath>                     a file with line-separated list of QBiC sample ids
   -s, --suffix=<suffix>[,<suffix>...]       only include files ending with one of these suffixes
   -h, --help                                display a help message and exit

--- a/config.txt
+++ b/config.txt
@@ -7,4 +7,4 @@
 -as https://openbis1605test.am10.uni-tuebingen.de/openbis/openbis
 
 # Set the DSS_URL (DataStoreServerURL) to the value defined below
--dss https://qbis.qbic.uni-tuebingen.de:444/datastore_server,https://qbis.qbic.uni-tuebingen.de:444/datastore_server2
+-dss https://qbis.qbic.uni-tuebingen.de/datastore_server,https://qbis.qbic.uni-tuebingen.de/datastore_server2

--- a/config.txt
+++ b/config.txt
@@ -7,5 +7,4 @@
 -as https://openbis1605test.am10.uni-tuebingen.de/openbis/openbis
 
 # Set the DSS_URL (DataStoreServerURL) to the value defined below
-# -dss https://qbis.qbic.uni-tuebingen.de:444/datastore_server
--dss https://openbis1605test.am10.uni-tuebingen.de/datastore_server
+-dss https://qbis.qbic.uni-tuebingen.de:444/datastore_server,https://qbis.qbic.uni-tuebingen.de:444/datastore_server2

--- a/src/main/groovy/life/qbic/DownloadException.groovy
+++ b/src/main/groovy/life/qbic/DownloadException.groovy
@@ -21,4 +21,8 @@ class DownloadException extends RuntimeException {
     super(m)
   }
 
+  DownloadException(Throwable cause) {
+    super(cause)
+  }
+
 }

--- a/src/main/groovy/life/qbic/DownloadRequest.groovy
+++ b/src/main/groovy/life/qbic/DownloadRequest.groovy
@@ -14,74 +14,29 @@ import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile
  */
 class DownloadRequest {
 
-  final private Map<String, DataSetFile> dataSetByPermId
+  private final String datasetSampleCode;
 
-  private String sampleCode
+  private final List<DataSetFile> dataSetFiles;
 
-  private int retries
+  private final int retries
 
-  DownloadRequest() {
-    this.dataSetByPermId = new HashMap<>()
-    this.sampleCode = ""
-    this.retries = 1
-  }
-
-  /**
-   * Download request constructor with a provided list of data set files.
-   *
-   * @param dataSetFiles
-   */
-  DownloadRequest(List<DataSetFile> dataSetFiles, String sampleCode) {
-    this()
-    this.sampleCode = sampleCode
-    dataSetFiles.each { dsFile ->
-      addDataSet(dsFile.getPermId().toString(), dsFile)
-    }
-    this.retries = 1
-  }
 
   /**
    * Download request constructor with a provided list of data set files and a configured
    * number of retries on failure.
    *
-   * @param dataSetFiles
-   * @param sampleCode
+   * @param datasetSampleCode the code of the sample to which the dataset was attached
+   * @param dataSetFiles the files to download
    * @param numberRetries The number of retries. Must be >=1, else it will be set to 1
    */
-  DownloadRequest(List<DataSetFile> dataSetFiles, String sampleCode, int numberRetries) {
-    this()
-    this.sampleCode = sampleCode
-    dataSetFiles.each { dsFile ->
-      addDataSet(dsFile.getPermId().toString(), dsFile)
-    }
-    this.retries = numberRetries >= 1 ? numberRetries : 1
-  }
+  DownloadRequest(String datasetSampleCode, List<DataSetFile> dataSetFiles, int numberRetries) {
+    Objects.requireNonNull(datasetSampleCode, "sample code of dataset must not be null")
+    Objects.requireNonNull(dataSetFiles, "dataset files must not be null")
 
-  /**
-   * Adds a data set file to the download request.
-   *
-   * @param permId The openBIS permId.
-   * @param dataSetFile A data set file that shall be downloaded.
-   */
-  void addDataSet(String permId, DataSetFile dataSetFile) {
-    if (dataSetByPermId.containsKey(permId)) {
-      def list = dataSetByPermId[permId]
-      list << dataSetFile
-    } else {
-      dataSetByPermId[permId] = dataSetFile
-    }
-  }
-  /**
-   * Returns the CRC32 checksum for a data set with the provided permID.
-   *
-   * @param permId An openBIS data set file permId for which the checksum shall be returned.
-   * @return The associated CRC32 checksum from the openBIS data base.
-   */
-  int getCRC32sum(String permId) {
-    if (!dataSetByPermId[permId].checksumCRC32) {
-      new IllegalArgumentException("The provided argument does not represent a known ID.")
-    }
-    return dataSetByPermId[permId].checksumCRC32
+    this.dataSetFiles = new ArrayList<>()
+    this.dataSetFiles.addAll(dataSetFiles)
+    this.retries = numberRetries >= 1 ? numberRetries : 1
+    this.datasetSampleCode = datasetSampleCode
   }
 
   /**
@@ -96,12 +51,11 @@ class DownloadRequest {
    * Returns a shallow copy of the data set file list from the download request.
    * @return A list of all requested data set files.
    */
-  List<DataSetFile> getDataSets() {
-    dataSetByPermId.values().collect()
+  List<DataSetFile> getFiles() {
+    dataSetFiles.asUnmodifiable()
   }
 
-  String getSampleCode() {
-    sampleCode
+  String getDatasetSampleCode() {
+    return datasetSampleCode
   }
-
 }

--- a/src/main/groovy/life/qbic/DownloadRequest.groovy
+++ b/src/main/groovy/life/qbic/DownloadRequest.groovy
@@ -2,6 +2,8 @@ package life.qbic
 
 import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile
 
+import java.nio.file.Path
+
 /**
  * Contains information about a download request for openBIS
  * data set files.
@@ -13,11 +15,8 @@ import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile
  * @since 0.4.0
  */
 class DownloadRequest {
-
-  private final String datasetSampleCode;
-
   private final List<DataSetFile> dataSetFiles;
-
+  private final Path prefix
   private final int retries
 
 
@@ -29,14 +28,14 @@ class DownloadRequest {
    * @param dataSetFiles the files to download
    * @param numberRetries The number of retries. Must be >=1, else it will be set to 1
    */
-  DownloadRequest(String datasetSampleCode, List<DataSetFile> dataSetFiles, int numberRetries) {
-    Objects.requireNonNull(datasetSampleCode, "sample code of dataset must not be null")
-    Objects.requireNonNull(dataSetFiles, "dataset files must not be null")
+  DownloadRequest(Path prefix, List<DataSetFile> dataSetFiles, int numberRetries) {
+    Objects.requireNonNull(prefix, "prefix must not be null")
+    Objects.requireNonNull(dataSetFiles, "files must not be null")
 
     this.dataSetFiles = new ArrayList<>()
     this.dataSetFiles.addAll(dataSetFiles)
     this.retries = numberRetries >= 1 ? numberRetries : 1
-    this.datasetSampleCode = datasetSampleCode
+    this.prefix = prefix
   }
 
   /**
@@ -55,7 +54,7 @@ class DownloadRequest {
     dataSetFiles.asUnmodifiable()
   }
 
-  String getDatasetSampleCode() {
-    return datasetSampleCode
+  Path getPrefix() {
+    return prefix
   }
 }

--- a/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
+++ b/src/main/java/life/qbic/io/commandline/PostmanCommandLineOptions.java
@@ -5,6 +5,7 @@ import static java.util.Objects.nonNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import life.qbic.App;
 import life.qbic.io.parser.IdentifierParser;
@@ -54,7 +55,7 @@ public class PostmanCommandLineOptions {
     QbicDataDownloader qbicDataDownloader =
         new QbicDataDownloader(
             as_url,
-            dss_url,
+            dss_urls,
             bufferMultiplier * 1024,
             conservePath,
             authentication.getSessionToken(),
@@ -74,7 +75,8 @@ public class PostmanCommandLineOptions {
   void listDatasets()
       throws IOException {
     Authentication authentication = App.loginToOpenBIS(passwordEnvVariable, user, as_url);
-    QbicDataDisplay qbicDataDisplay = new QbicDataDisplay(as_url, dss_url,
+    QbicDataDisplay qbicDataDisplay = new QbicDataDisplay(as_url,
+        dss_urls,
         authentication.getSessionToken());
     ids = verifyProvidedIdentifiers();
     qbicDataDisplay.getInformation(ids, suffixes);
@@ -103,10 +105,15 @@ public class PostmanCommandLineOptions {
   public String as_url = "https://qbis.qbic.uni-tuebingen.de/openbis/openbis";
 
   @Option(
-          names = {"-dss", "--dss_url"},
-          description = "DataStoreServer URL",
-          scope = CommandLine.ScopeType.INHERIT)
-  public String dss_url = "https://qbis.qbic.uni-tuebingen.de/datastore_server";
+      names = {"-dss", "--dss_url"},
+      split = ",",
+      paramLabel = "<url>",
+      description = "DataStoreServer URLs. Specifies the data store servers where data can be found.",
+      scope = CommandLine.ScopeType.INHERIT)
+  public List<String> dss_urls = new ArrayList<String>(){{
+    add("https://qbis.qbic.uni-tuebingen.de/datastore_server");
+    add("https://qbis.qbic.uni-tuebingen.de/datastore_server2");
+  }};
 
   @Option(
           names = {"-f", "--file"},

--- a/src/main/java/life/qbic/model/download/OutputPathFinder.java
+++ b/src/main/java/life/qbic/model/download/OutputPathFinder.java
@@ -27,7 +27,7 @@ public class OutputPathFinder {
         return Files.isDirectory(path);
     }
 
-    public static Path determineFinalPathFromDataset(DataSetFile file, Boolean conservePaths ) {
+    private static Path determineFinalPathFromDataset(DataSetFile file, Boolean conservePaths ) {
         Path finalPath;
         if (conservePaths) {
             finalPath = Paths.get(file.getPath());

--- a/src/main/java/life/qbic/model/download/QbicDataDisplay.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDisplay.java
@@ -33,7 +33,7 @@ public class QbicDataDisplay {
 
     public QbicDataDisplay(
             String AppServerUri,
-            String DataServerUri,
+            List<String> dataServerUris,
             String sessionToken) {
         this.sessionToken = sessionToken;
         IApplicationServerApi applicationServer;
@@ -44,15 +44,14 @@ public class QbicDataDisplay {
         } else {
             applicationServer = null;
         }
-        IDataStoreServerApi dataStoreServer;
-        if (!DataServerUri.isEmpty()) {
-            dataStoreServer =
-                    HttpInvokerUtils.createStreamSupportingServiceStub(
-                            IDataStoreServerApi.class, DataServerUri + IDataStoreServerApi.SERVICE_URL, 10000);
-        } else {
-            dataStoreServer = null;
-        }
-        qbicDataFinder = new QbicDataFinder(applicationServer, dataStoreServer, sessionToken);
+        List<IDataStoreServerApi> dataStoreServerApis = dataServerUris.stream()
+            .filter(dataStoreServerUri -> !dataStoreServerUri.isEmpty())
+            .map(dataStoreServerUri ->
+                HttpInvokerUtils.createStreamSupportingServiceStub(
+                    IDataStoreServerApi.class, dataStoreServerUri + IDataStoreServerApi.SERVICE_URL,
+                    10000))
+            .collect(Collectors.toList());
+        qbicDataFinder = new QbicDataFinder(applicationServer, dataStoreServerApis, sessionToken);
     }
 
     public void getInformation(List<String> ids, List<String> suffixes){

--- a/src/main/java/life/qbic/model/download/QbicDataDisplay.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDisplay.java
@@ -14,7 +14,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import life.qbic.model.files.FileSize;
@@ -93,7 +92,7 @@ public class QbicDataDisplay {
 
                 long totalSize = dataSetFiles.stream().mapToLong(DataSetFile::getFileLength).sum();
 
-                Sample analyte = searchAnalyteParent(entry.getKey());
+                Sample analyte = qbicDataFinder.searchAnalyteParent(entry.getKey());
                 Date registrationDate = dataSet.getRegistrationDate();
                 String iso_registrationDate = utcDateTimeFormatterIso8601.format(registrationDate.toInstant());
                 int columnWidth = 16;
@@ -123,20 +122,6 @@ public class QbicDataDisplay {
     private static String getFileName(DataSetFile file) {
         String filePath = file.getPermId().getFilePath();
         return filePath.substring(filePath.lastIndexOf("/") + 1);
-    }
-
-    /**
-     * Searches the parents for a Q_TEST_SAMPLE assuming at most one Q_TEST_SAMPLE exists in the parent samples.
-     * If not Q_TEST_SAMPLE was found, the original sample is returned.
-     * @param sample the sample to which a dataset is attached to
-     * @return the Q_TEST_SAMPLE parent if exists, the sample itself otherwise.
-     */
-    private Sample searchAnalyteParent(Sample sample) {
-        Optional<Sample> firstTestSample = sample.getParents().stream()
-            .filter(
-                it -> it.getType().getCode().equals("Q_TEST_SAMPLE"))
-            .findFirst();
-        return firstTestSample.orElse(sample);
     }
 
 

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -236,23 +236,19 @@ public class QbicDataDownloader {
         } catch (IOException e) {
           throw new DownloadException(e);
         }
-        doChecksumLogic(dataSetFile, finalPath, computedChecksum);
+        ChecksumValidationResult checksumValidationResult = validateChecksum(computedChecksum,
+            dataSetFile);
+        if (checksumValidationResult.isValid()) {
+          LOG.info("Download successful for " + finalPath.toAbsolutePath());
+        } else if (checksumValidationResult.isInvalid()) {
+          LOG.warn(String.format(
+              "Checksum mismatches were detected for file %s.%nFor more Information check the logs/summary_invalid_files.txt log file.",
+              finalPath.toAbsolutePath()));
+        }
+        reportValidation(checksumValidationResult);
       } else {
         LOG.info("Skipped empty file " + file.getDataSetFile().getPath());
       }
-    }
-  }
-
-  private void doChecksumLogic(DataSetFile dataSetFile, Path filePath, long computedChecksum) {
-    ChecksumValidationResult checksumValidationResult = validateChecksum(computedChecksum,
-        dataSetFile);
-    reportValidation(checksumValidationResult);
-    if (checksumValidationResult.isValid()) {
-      LOG.info("Download successful for " + filePath.toAbsolutePath());
-    } else if (checksumValidationResult.isInvalid()) {
-      LOG.warn(String.format(
-          "Checksum mismatches were detected for file %s.%nFor more Information check the logs/summary_invalid_files.txt log file.",
-          filePath.toAbsolutePath()));
     }
   }
 

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -144,6 +144,7 @@ public class QbicDataDownloader {
         LOG.info("Nothing to download for " + ident+".");
       }
     }
+    LOG.info("Done");
   }
 
   private Map<Sample, List<DataSet>> associateDatasetsWithAnalyte(Map<Sample, List<DataSet>> foundDataSets) {
@@ -166,6 +167,10 @@ public class QbicDataDownloader {
     List<DataSet> sortedDatasets = dataSets.stream()
         .sorted(Comparator.comparing(it -> it.getSample().getCode()))
         .collect(Collectors.toList());
+
+    if (sortedDatasets.size() == 0) {
+      return;
+    }
 
     LOG.info(String.format("Found " + sortedDatasets.size() + " dataset(s) for sample %s",
         analyte.getCode()));

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -75,9 +75,9 @@ public class QbicDataFinder {
           .getObjects();
       if (filesOnDataStoreServer.isEmpty()) {
         log.debug(
-            String.format("No files found in dataset %s on dss %s%n", permID, dataStoreServer));
+            String.format("No files found in dataset %s on dss %s", permID, dataStoreServer));
       } else {
-        log.debug(String.format("%s files found in dataset %s on dss %s%n",
+        log.debug(String.format("%s files and directories found in dataset %s on dss %s",
             filesOnDataStoreServer.size(), permID, dataStoreServer));
       }
       files.addAll(filesOnDataStoreServer);

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -19,9 +19,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import jline.internal.Log;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class QbicDataFinder {
+
+  private static final Logger log = LogManager.getLogger(QbicDataFinder.class);
 
   private final IApplicationServerApi applicationServer;
 
@@ -71,10 +74,10 @@ public class QbicDataFinder {
           .searchFiles(sessionToken, criteria, new DataSetFileFetchOptions())
           .getObjects();
       if (filesOnDataStoreServer.isEmpty()) {
-        Log.debug(
+        log.debug(
             String.format("No files found in dataset %s on dss %s%n", permID, dataStoreServer));
       } else {
-        Log.debug(String.format("%s files found in dataset %s on dss %s%n",
+        log.debug(String.format("%s files found in dataset %s on dss %s%n",
             filesOnDataStoreServer.size(), permID, dataStoreServer));
       }
       files.addAll(filesOnDataStoreServer);

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -12,27 +12,29 @@ import ch.ethz.sis.openbis.generic.dssapi.v3.IDataStoreServerApi;
 import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.DataSetFile;
 import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.fetchoptions.DataSetFileFetchOptions;
 import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.search.DataSetFileSearchCriteria;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import jline.internal.Log;
 
 public class QbicDataFinder {
 
   private final IApplicationServerApi applicationServer;
 
-  private final IDataStoreServerApi dataStoreServer;
+  private final List<IDataStoreServerApi> dataStoreServers;
 
   private final String sessionToken;
 
   public QbicDataFinder(
       IApplicationServerApi applicationServer,
-      IDataStoreServerApi dataStoreServer,
+      List<IDataStoreServerApi> dataStoreServers,
       String sessionToken) {
     this.applicationServer = applicationServer;
-    this.dataStoreServer = dataStoreServer;
+    this.dataStoreServers = dataStoreServers;
     this.sessionToken = sessionToken;
   }
 
@@ -62,9 +64,22 @@ public class QbicDataFinder {
   public List<DataSetFile> getFiles(DataSetPermId permID, Predicate<DataSetFile> fileFilter) {
       DataSetFileSearchCriteria criteria = new DataSetFileSearchCriteria();
       criteria.withDataSet().withCode().thatEquals(permID.getPermId());
-    List<DataSetFile> files = dataStoreServer
-        .searchFiles(sessionToken, criteria, new DataSetFileFetchOptions())
-        .getObjects();
+    List<DataSetFile> files = new ArrayList<>();
+    // add files from all data store servers
+    for (IDataStoreServerApi dataStoreServer : dataStoreServers) {
+      List<DataSetFile> filesOnDataStoreServer = dataStoreServer
+          .searchFiles(sessionToken, criteria, new DataSetFileFetchOptions())
+          .getObjects();
+      if (filesOnDataStoreServer.isEmpty()) {
+        Log.debug(
+            String.format("No files found in dataset %s on dss %s%n", permID, dataStoreServer));
+      } else {
+        Log.debug(String.format("%s files found in dataset %s on dss %s%n",
+            filesOnDataStoreServer.size(), permID, dataStoreServer));
+      }
+      files.addAll(filesOnDataStoreServer);
+    }
+
     Predicate<DataSetFile> notADirectory = dataSetFile -> !dataSetFile.isDirectory();
     return files.stream().filter(notADirectory.and(fileFilter)).collect(Collectors.toList());
   }

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -15,6 +15,7 @@ import ch.ethz.sis.openbis.generic.dssapi.v3.dto.datasetfile.search.DataSetFileS
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -98,5 +99,20 @@ public class QbicDataFinder {
       fillWithDescendantDatasets(sample, dataSetsBySample);
     }
     return dataSetsBySample;
+  }
+
+  /**
+   * Searches the parents for a Q_TEST_SAMPLE assuming at most one Q_TEST_SAMPLE exists in the parent
+   * samples. If not Q_TEST_SAMPLE was found, the original sample is returned.
+   *
+   * @param sample the sample to which a dataset is attached to
+   * @return the Q_TEST_SAMPLE parent if exists, the sample itself otherwise.
+   */
+  public Sample searchAnalyteParent(Sample sample) {
+      Optional<Sample> firstTestSample = sample.getParents().stream()
+          .filter(
+              it -> it.getType().getCode().equals("Q_TEST_SAMPLE"))
+          .findFirst();
+      return firstTestSample.orElse(sample);
   }
 }

--- a/src/main/java/life/qbic/model/download/QbicDataFinder.java
+++ b/src/main/java/life/qbic/model/download/QbicDataFinder.java
@@ -103,7 +103,7 @@ public class QbicDataFinder {
 
   /**
    * Searches the parents for a Q_TEST_SAMPLE assuming at most one Q_TEST_SAMPLE exists in the parent
-   * samples. If not Q_TEST_SAMPLE was found, the original sample is returned.
+   * samples. If no Q_TEST_SAMPLE was found, the original sample is returned.
    *
    * @param sample the sample to which a dataset is attached to
    * @return the Q_TEST_SAMPLE parent if exists, the sample itself otherwise.

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,8 +9,8 @@
     </File>
   </Appenders>
   <Loggers>
-    <Root level="info">
-      <AppenderRef ref="Console"/>
+    <Root level="debug">
+      <AppenderRef ref="Console" level="info"/>
       <AppenderRef ref="MyFile"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
```
10:07:13.085 [main] INFO  life.qbic.model.download.QbicDataDownloader - 1 provided openBIS identifiers have been found: [***]
10:07:13.301 [main] INFO  life.qbic.model.download.QbicDataDownloader - Found 3 dataset(s) for sample ***
10:07:13.540 [main] INFO  life.qbic.model.download.QbicDataDownloader - Downloading 4 files for dataset *** (***)
10:07:13.710 [main] INFO  life.qbic.model.download.QbicDataDownloader - Skipped empty file ***.sha256sum
10:07:13.878 [main] INFO  life.qbic.model.download.QbicDataDownloader - Skipped empty file ***.sha256sum
10:07:14.026 [main] INFO  life.qbic.model.download.QbicDataDownloader - Skipped empty file ***.fast5
10:07:14.186 [main] INFO  life.qbic.model.download.QbicDataDownloader - Skipped empty file ***.fast5
10:07:14.605 [main] INFO  life.qbic.model.download.QbicDataDownloader - Downloading 1855 files for dataset *** (***)
10:07:21.448 [main] INFO  life.qbic.model.download.QbicDataDownloader - Download successful for /***/***.fastq.gz
10:07:28.588 [main] INFO  life.qbic.model.download.QbicDataDownloader - Download successful for /***/***.fastq.gz
***_...      [#############             ]	  7.54 MB / 15.08 MB [00:00:03] (2.21 Mb/s)
```