### PR TITLE
Skip empty files when downloading

### DIFF
--- a/src/main/groovy/life/qbic/FileSystemWriter.groovy
+++ b/src/main/groovy/life/qbic/FileSystemWriter.groovy
@@ -59,6 +59,12 @@ class FileSystemWriter implements ChecksumReporter {
   @Override
   void storeChecksum(Path filePath, String checksum) {
     def newFile = new File(filePath.toString() + ".crc32")
+    if (!newFile.createNewFile()) {
+      //file exists or could not be created
+      if (!newFile.exists()) {
+        throw new IOException("The file " + newFile.getAbsoluteFile() + " could not be created.")
+      }
+    }
     newFile.withWriter {
       it.write(checksum + "\t" + filePath.getFileName())
     }

--- a/src/main/java/life/qbic/model/download/QbicDataDownloader.java
+++ b/src/main/java/life/qbic/model/download/QbicDataDownloader.java
@@ -256,8 +256,14 @@ public class QbicDataDownloader {
       int downloadAttempt = 1;
       while (downloadAttempt <= request.getMaxNumberOfAttempts()) {
         try {
-          downloadFile(dataSetFile, pathPrefix);
-          writeCRC32Checksum(dataSetFile, pathPrefix);
+          if (dataSetFile.getFileLength() > 0) {
+            downloadFile(dataSetFile, pathPrefix);
+            writeCRC32Checksum(dataSetFile, pathPrefix);
+          } else {
+            LOG.warn("Skipped empty file " + dataSetFile.getPath()
+                .substring(dataSetFile.getPath().lastIndexOf("original/") + 9));
+          }
+
           return;
         } catch (Exception e) {
           LOG.error(String.format("Download attempt %d failed.", downloadAttempt));


### PR DESCRIPTION
This PR addresses an issue with empty files. Previously empty files were skipped but postman-cli tried to write the checksum file. This led to errors as the directory was not created and the file was not downloaded.
The issue is addressed by skipping empty files completely and stating a warning in the log.