### PR TITLE
Add an additional data store to the default data stores

### DIFF
--- a/src/main/java/life/qbic/qpostman/common/options/ServerOptions.java
+++ b/src/main/java/life/qbic/qpostman/common/options/ServerOptions.java
@@ -20,7 +20,8 @@ public class ServerOptions {
         hidden = true)
     public List<String> dss_urls = new ArrayList<>(List.of(
         "https://qbis.qbic.uni-tuebingen.de/datastore_server",
-        "https://qbis.qbic.uni-tuebingen.de/datastore_server2"
+        "https://qbis.qbic.uni-tuebingen.de/datastore_server2",
+        "https://qbis.qbic.uni-tuebingen.de/datastore_server_attachments"
     ));
 
 


### PR DESCRIPTION
Adds `https://qbis.qbic.uni-tuebingen.de/datastore_server_attachments` to the configured DSS