### PR TITLE
Add `--ignore-subdirectories` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ NGSQSTTS015A0 (20211026111452695-847006)	NGSQSTTS015A0	2021-10-26T09:14:53.14381
 ## `download`
 
 ```txt
-Usage: postman-cli download [-hV] [-o=<outputPath>] -u=<user> [-s=<suffix>[,
-                            <suffix>...]]... (--password:
-                            env=<environment-variable> | --password:
+Usage: postman-cli download [-hV] [--ignore-subdirectories] [-o=<outputPath>]
+                            -u=<user> [-s=<suffix>[,<suffix>...]]...
+                            (--password:env=<environment-variable> | --password:
                             prop=<system-property> | --password) (-f=<filePath>
                             | SAMPLE_IDENTIFIER...)
 
@@ -246,17 +246,36 @@ Options:
                                (case-insensitive) suffixes
   -o, --output-dir=<outputPath>
                              specify where to write the downloaded data
+      --ignore-subdirectories
+                             put all files into one directory regardless of the
+                               directory structure on the server; conflicts
+                               with files with equal names are not addressed
   -h, --help                 Show this help message and exit.
   -V, --version              Print version information and exit.
 
 Optional: specify a config file by running postman with '@/path/to/config.txt'.
-A detailed documentation can be found at
-https://github.com/qbicsoftware/postman-cli#readme.
+A detailed documentation can be found at https://github.com/qbicsoftware/postman-cli#readme.
 ```
 The `download` command allows you to download data from our storage to your machine. 
 
 Use the `--output-dir` option to specify a location on your client the location will be interpreted relative to your working directory.
 
+By using the `--ignore-subdirectories` flag, you signal qpostman that you are not interested in the directory structure on the server.
+qpostman will thus put all files it finds into the same top-level folder.
+
+**default download behaviour**
+```text
+my/awesome/path/file1.fastq.gz            -> QABCD/my/awesome/path/file1.fastq.gz
+my/awesome/other/path/file2.fastq.gz      -> QABCD/my/awesome/other/path/file2.fastq.gz
+my/awesome/additional/path/file3.fastq.gz -> QABCD/my/awesome/additional/path/file3.fastq.gz
+```
+**with `--ignore-subdirectories`**
+```text
+with --ignore-subdirectories
+my/awesome/path/file1.fastq.gz            -> QABCD/file1.fastq.gz
+my/awesome/other/path/file2.fastq.gz      -> QABCD/file2.fastq.gz
+my/awesome/additional/path/file3.fastq.gz -> QABCD/file3.fastq.gz
+```
 ##### File integrity check
 Postman computes the CRC32 checksum for all input streams using the native Java utility class [CRC32](https://docs.oracle.com/javase/8/docs/api/java/util/zip/CRC32.html). Postman favours [`CheckedInputStream`](https://docs.oracle.com/javase/7/docs/api/java/util/zip/CheckedInputStream.html)
 over the traditional InputStream, and promotes the CRC checksum computation.

--- a/src/main/java/life/qbic/qpostman/common/functions/FindSourceSample.java
+++ b/src/main/java/life/qbic/qpostman/common/functions/FindSourceSample.java
@@ -3,6 +3,7 @@ package life.qbic.qpostman.common.functions;
 import static java.util.Objects.requireNonNull;
 
 import ch.ethz.sis.openbis.generic.asapi.v3.dto.sample.Sample;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -23,10 +24,11 @@ public class FindSourceSample implements Function<Sample, Sample> {
         if (sample.getType().getCode().equals(sourceSampleTypeCode)) {
             return Optional.of(sample);
         }
-        if (sample.getParents().isEmpty()) {
+        List<Sample> parents = sample.getParents();
+        if (parents.isEmpty()) {
             return Optional.empty();
         }
-        for (Sample parent : sample.getParents()) {
+        for (Sample parent : parents) {
             Optional<Sample> sourceSample = findSourceSample(parent);
             if (sourceSample.isPresent()) {
                 return sourceSample;

--- a/src/main/java/life/qbic/qpostman/download/DownloadCommand.java
+++ b/src/main/java/life/qbic/qpostman/download/DownloadCommand.java
@@ -124,7 +124,8 @@ public class DownloadCommand implements Runnable {
         SearchDataSets searchDataSets = new SearchDataSets(applicationServerApi);
         FileFilter myAwesomeFileFilter = FileFilter.create().withSuffixes(filterOptions.suffixes);
         WriteFileToDisk writeFileToDisk = new WriteFileToDisk(dataStoreServerApis().toArray(IDataStoreServerApi[]::new)[0],
-            downloadOptions.bufferSize, Path.of(downloadOptions.outputPath), downloadOptions.successiveDownloadAttempts);
+            downloadOptions.bufferSize, Path.of(downloadOptions.outputPath), downloadOptions.successiveDownloadAttempts,
+            downloadOptions.ignoreDirectories);
         FindSourceSample findSourceSample = new FindSourceSample(serverOptions.sourceSampleType);
         SortFiles sortFiles = new SortFiles();
         DataSetWrapper.setFindSourceFunction(findSourceSample);

--- a/src/main/java/life/qbic/qpostman/download/DownloadCommand.java
+++ b/src/main/java/life/qbic/qpostman/download/DownloadCommand.java
@@ -125,7 +125,7 @@ public class DownloadCommand implements Runnable {
         FileFilter myAwesomeFileFilter = FileFilter.create().withSuffixes(filterOptions.suffixes);
         WriteFileToDisk writeFileToDisk = new WriteFileToDisk(dataStoreServerApis().toArray(IDataStoreServerApi[]::new)[0],
             downloadOptions.bufferSize, Path.of(downloadOptions.outputPath), downloadOptions.successiveDownloadAttempts,
-            downloadOptions.ignoreDirectories);
+            downloadOptions.ignoreSubDirectories);
         FindSourceSample findSourceSample = new FindSourceSample(serverOptions.sourceSampleType);
         SortFiles sortFiles = new SortFiles();
         DataSetWrapper.setFindSourceFunction(findSourceSample);

--- a/src/main/java/life/qbic/qpostman/download/DownloadOptions.java
+++ b/src/main/java/life/qbic/qpostman/download/DownloadOptions.java
@@ -5,6 +5,7 @@ import static picocli.CommandLine.Option;
 
 import java.util.Optional;
 import java.util.StringJoiner;
+import picocli.CommandLine.Help.Visibility;
 
 public class DownloadOptions {
     @Option(names = {"--buffer-size"},
@@ -25,6 +26,11 @@ public class DownloadOptions {
         description = "how often to attempt file download in case the download failed",
         hidden = true)
     public int successiveDownloadAttempts;
+
+    @Option(names = "--ignore-directories", defaultValue = "false",
+        description = "put all files into one directory regardless of the directory structure on the server; conflicts with files with equal names are not addressed ",
+        showDefaultValue = Visibility.ON_DEMAND)
+    public boolean ignoreDirectories;
 
     @Override
     public String toString() {

--- a/src/main/java/life/qbic/qpostman/download/DownloadOptions.java
+++ b/src/main/java/life/qbic/qpostman/download/DownloadOptions.java
@@ -27,10 +27,10 @@ public class DownloadOptions {
         hidden = true)
     public int successiveDownloadAttempts;
 
-    @Option(names = "--ignore-directories", defaultValue = "false",
-        description = "put all files into one directory regardless of the directory structure on the server; conflicts with files with equal names are not addressed ",
+    @Option(names = "--ignore-subdirectories", defaultValue = "false",
+        description = "put all files into one directory regardless of the directory structure on the server; conflicts with files with equal names are not addressed",
         showDefaultValue = Visibility.ON_DEMAND)
-    public boolean ignoreDirectories;
+    public boolean ignoreSubDirectories;
 
     @Override
     public String toString() {

--- a/src/main/java/life/qbic/qpostman/download/WriteFileToDisk.java
+++ b/src/main/java/life/qbic/qpostman/download/WriteFileToDisk.java
@@ -44,12 +44,9 @@ public class WriteFileToDisk implements Function<DataFile, DownloadReport> {
     }
 
     private Path toOutputPath(DataFile dataFile, Path outputDirectory) {
-        if (this.ignoreDirectories) {
-            Path sampleOutDir = outputDirectory.resolve(dataFile.dataSet().sampleCode()); // outdir/QABCDEFG/
-            return sampleOutDir.resolve(dataFile.fileName()); // outdir/QABCDEF/file.name
-        } else {
-            return outputDirectory.resolve(dataFile.filePath()); // outdir/file/path/file.name
-        }
+        Path datasetSampleOut = outputDirectory.resolve(dataFile.dataSet().sampleCode());
+        String fileSpecific = ignoreDirectories ? dataFile.fileName() : dataFile.filePath();
+        return datasetSampleOut.resolve(fileSpecific);
     }
 
     private AutoClosableDataSetFileDownloadReader toReader(DataFile dataFile) {


### PR DESCRIPTION
The default behaviour for the download command is to create the same directory structure on the client as on the server, prefixed with the specified output directory.

This flag ignores the directory structure and downloads all files into the output directory directly grouped by dataset sample.
Caution: This might lead to files with the same names overwriting each other.